### PR TITLE
new kernel timers api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CC=${CROSS_COMPILE}gcc
 all: genl_ex genl_ex.ko
 
 genl_ex: genl_ex.h genl_ex.c
-	$(CC) -Wextra -Wall -Werror -Wno-unused-parameter $(NL_LIB_FLAGS) $(NL_LIBS_L) $(NL_LIBS_l) genl_ex.c -o genl_ex
+	$(CC) -Wextra -Wall -Werror -Wno-unused-parameter genl_ex.c $(NL_LIB_FLAGS) $(NL_LIBS_L) $(NL_LIBS_l) -o genl_ex
 
 genl_ex.ko:
 	$(MAKE) -C $(shell pwd)/kernel KERNEL_DIR=$(KERNEL_DIR) 

--- a/kernel/genl_ex.c
+++ b/kernel/genl_ex.c
@@ -50,7 +50,11 @@ nlmsg_fail:
 	return;
 }
 
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(4,14,0)
 void genl_test_periodic(unsigned long data)
+#else
+void genl_test_periodic(struct timer_list *unused)
+#endif
 {
 	greet_group(GENL_TEST_MCGRP0);
 	greet_group(GENL_TEST_MCGRP1);
@@ -110,11 +114,16 @@ static int __init genl_test_init(void)
 	if (rc)
 		goto failure;
 
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(4,14,0)
 	init_timer(&timer);
 	timer.data = 0;
 	timer.function = genl_test_periodic;
 	timer.expires = jiffies + msecs_to_jiffies(GENL_TEST_HELLO_INTERVAL);
 	add_timer(&timer);
+#else
+	timer_setup(&timer, genl_test_periodic, 0);
+	mod_timer(&timer, jiffies + msecs_to_jiffies(GENL_TEST_HELLO_INTERVAL));
+#endif
 
 	return 0;
 


### PR DESCRIPTION
New kernel timers api with universal solution for old (< 4.14) and newer Kernels